### PR TITLE
Fix relay handling to call relay policies.

### DIFF
--- a/slimta/celeryqueue/__init__.py
+++ b/slimta/celeryqueue/__init__.py
@@ -149,7 +149,7 @@ class CeleryQueue(object):
 
     def attempt_delivery(self, envelope, attempts):
         try:
-            self.relay.attempt(envelope, attempts)
+            self.relay._attempt(envelope, attempts)
         except TransientRelayError as exc:
             self._handle_transient_failure(envelope, attempts, exc.reply)
         except PermanentRelayError as exc:


### PR DESCRIPTION
They were never called. Fixed unit tests to check on the right method as well:
`relay._attempt` is the one that takes care of calling the relay handlers.

@icgood I am not yet very confident with the way mox works, and would be curious to see how you'd check that a relay policy is actually called.